### PR TITLE
Add is_symmetric property

### DIFF
--- a/binarytree/__init__.py
+++ b/binarytree/__init__.py
@@ -57,6 +57,27 @@ def _is_bst(root, min_value=float('-inf'), max_value=float('inf')):
     )
 
 
+def _is_symmetric(root):
+    """Check if the binary tree is symmetric
+
+    :param root: Root node of the binary tree
+    :type root: binarytree.Node | None
+    :return: True if the binary tree is symmetric, False otherwise.
+    :rtype: bool
+    """
+    def symmetric_helper(left_subtree, right_subtree):
+        if left_subtree is None and right_subtree is None:
+            return True
+        if left_subtree is None or right_subtree is None:
+            return False
+        return (
+            left_subtree.value == right_subtree.value and
+            symmetric_helper(left_subtree.left, right_subtree.right) and
+            symmetric_helper(left_subtree.right, right_subtree.left)
+        )
+    return symmetric_helper(root, root)
+
+
 def _validate_tree_height(height):
     """Check if the height of the binary tree is valid.
 
@@ -1104,6 +1125,40 @@ class Node(object):
         return _is_bst(self, float('-inf'), float('inf'))
 
     @property
+    def is_symmetric(self):
+        """Check if the binary tree is symmetric.
+
+        * Left subtree is a mirror of the right subtree around the center
+
+        :return: True if the binary tree is a symmetric, False otherwise.
+        :rtype: bool
+
+        **Example**:
+
+        .. doctest::
+
+            >>> from binarytree import Node
+            >>> root = Node(1)
+            >>> root.left = Node(2)
+            >>> root.right = Node(2)
+            >>> root.left.left = Node(3)
+            >>> root.left.right = Node(4)
+            >>> root.right.left = Node(4)
+            >>> root.right.right = Node(3)
+            >>> print(root)
+            <BLANKLINE>
+                __1__
+               /     \\
+              2       2
+             / \\     / \\
+            3   4   4   3
+            <BLANKLINE>
+            >>> root.is_symmetric
+            True
+        """
+        return _is_symmetric(self)
+
+    @property
     def is_max_heap(self):
         """Check if the binary tree is a `max heap`_.
 
@@ -1424,6 +1479,8 @@ class Node(object):
             False
             >>> props['is_complete']    # equivalent to root.is_complete
             True
+            >>> props['is_symmetric']   # equivalent to root.is_symmetric
+            False
             >>> props['is_max_heap']    # equivalent to root.is_max_heap
             False
             >>> props['is_min_heap']    # equivalent to root.is_min_heap
@@ -1436,7 +1493,8 @@ class Node(object):
         properties = _get_tree_properties(self)
         properties.update({
             'is_bst': _is_bst(self),
-            'is_balanced': _is_balanced(self) >= 0
+            'is_balanced': _is_balanced(self) >= 0,
+            'is_symmetric': _is_symmetric(self)
         })
         return properties
 

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -414,6 +414,7 @@ def test_tree_properties():
         'is_min_heap': True,
         'is_perfect': True,
         'is_strict': True,
+        'is_symmetric': True,
         'leaf_count': 1,
         'max_leaf_depth': 0,
         'max_node_value': 1,
@@ -429,6 +430,7 @@ def test_tree_properties():
     assert root.is_min_heap is True
     assert root.is_perfect is True
     assert root.is_strict is True
+    assert root.is_symmetric is True
     assert root.leaf_count == 1
     assert root.max_leaf_depth == 0
     assert root.max_node_value == 1
@@ -446,6 +448,7 @@ def test_tree_properties():
         'is_min_heap': True,
         'is_perfect': False,
         'is_strict': False,
+        'is_symmetric': False,
         'leaf_count': 1,
         'max_leaf_depth': 1,
         'max_node_value': 2,
@@ -461,6 +464,7 @@ def test_tree_properties():
     assert root.is_min_heap is True
     assert root.is_perfect is False
     assert root.is_strict is False
+    assert root.is_symmetric is False
     assert root.leaf_count == 1
     assert root.max_leaf_depth == 1
     assert root.max_node_value == 2
@@ -478,6 +482,7 @@ def test_tree_properties():
         'is_min_heap': True,
         'is_perfect': True,
         'is_strict': True,
+        'is_symmetric': False,
         'leaf_count': 2,
         'max_leaf_depth': 1,
         'max_node_value': 3,
@@ -493,6 +498,7 @@ def test_tree_properties():
     assert root.is_min_heap is True
     assert root.is_perfect is True
     assert root.is_strict is True
+    assert root.is_symmetric is False
     assert root.leaf_count == 2
     assert root.max_leaf_depth == 1
     assert root.max_node_value == 3
@@ -510,6 +516,7 @@ def test_tree_properties():
         'is_min_heap': True,
         'is_perfect': False,
         'is_strict': False,
+        'is_symmetric': False,
         'leaf_count': 2,
         'max_leaf_depth': 2,
         'max_node_value': 4,
@@ -525,6 +532,7 @@ def test_tree_properties():
     assert root.is_min_heap is True
     assert root.is_perfect is False
     assert root.is_strict is False
+    assert root.is_symmetric is False
     assert root.leaf_count == 2
     assert root.max_leaf_depth == 2
     assert root.max_node_value == 4
@@ -542,6 +550,7 @@ def test_tree_properties():
         'is_min_heap': False,
         'is_perfect': False,
         'is_strict': False,
+        'is_symmetric': False,
         'leaf_count': 2,
         'max_leaf_depth': 2,
         'max_node_value': 5,
@@ -557,6 +566,7 @@ def test_tree_properties():
     assert root.is_min_heap is False
     assert root.is_perfect is False
     assert root.is_strict is False
+    assert root.is_symmetric is False
     assert root.leaf_count == 2
     assert root.max_leaf_depth == 2
     assert root.max_node_value == 5
@@ -574,6 +584,7 @@ def test_tree_properties():
         'is_min_heap': False,
         'is_perfect': False,
         'is_strict': False,
+        'is_symmetric': False,
         'leaf_count': 2,
         'max_leaf_depth': 3,
         'max_node_value': 6,
@@ -589,6 +600,7 @@ def test_tree_properties():
     assert root.is_min_heap is False
     assert root.is_perfect is False
     assert root.is_strict is False
+    assert root.is_symmetric is False
     assert root.leaf_count == 2
     assert root.max_leaf_depth == 3
     assert root.max_node_value == 6
@@ -606,6 +618,7 @@ def test_tree_properties():
         'is_min_heap': False,
         'is_perfect': False,
         'is_strict': False,
+        'is_symmetric': False,
         'leaf_count': 2,
         'max_leaf_depth': 3,
         'max_node_value': 7,
@@ -621,6 +634,7 @@ def test_tree_properties():
     assert root.is_min_heap is False
     assert root.is_perfect is False
     assert root.is_strict is False
+    assert root.is_symmetric is False
     assert root.leaf_count == 2
     assert root.max_leaf_depth == 3
     assert root.max_node_value == 7
@@ -861,6 +875,7 @@ def test_heap_float_values():
             assert root.is_min_heap == root_copy.is_min_heap
             assert root.is_perfect == root_copy.is_perfect
             assert root.is_strict == root_copy.is_strict
+            assert root.is_symmetric == root_copy.is_symmetric
             assert root.leaf_count == root_copy.leaf_count
             assert root.max_leaf_depth == root_copy.max_leaf_depth
             assert root.max_node_value == root_copy.max_node_value + 0.1


### PR DESCRIPTION
## Background
I enjoy using `binarytree`, especially find printing useful in `ipython`. 

I thought it would be fun to add a new property `is_symmetric` to properties. This comes up sometimes as an exercise with trees -- is it symmetric (a mirror of itself). 

Also wanted to learn more about the doctest and coverage modules 👍 

## Updates
1. Add new property and function to calculate if binary tree is symmetric

## Steps to Reproduce
```
>>> from binarytree import Node
>>> a = Node(5)
>>> a.is_symmetric
True
>>> a.left = Node(6)
>>> a.is_symmetric
False
>>> a.right = Node(6)
>>> a.is_symmetric
True
>>> a.right.left = Node(7)
>>> a.is_symmetric
False
>>> a.right.right = Node(8)
>>> a.left.left = Node(8)
>>> a.left.right = Node(7)
>>> print(a)

    __5__
   /     \
  6       6
 / \     / \
8   7   7   8

>>> a.is_symmetric
True
```