### PR TITLE
Account for deprecation of DiGraph._repr_svg_  in graphviz (#40)

### DIFF
--- a/binarytree/__init__.py
+++ b/binarytree/__init__.py
@@ -513,7 +513,7 @@ class Node:
                 return str(self.graphviz()._repr_svg_())
             except AttributeError:
                 # noinspection PyProtectedMember
-    	        return self.graphviz()._repr_image_svg_xml()
+                return self.graphviz()._repr_image_svg_xml()
 
         except (SubprocessError, ExecutableNotFound, FileNotFoundError):
             return self.svg()

--- a/binarytree/__init__.py
+++ b/binarytree/__init__.py
@@ -508,8 +508,12 @@ class Node:
         .. _Jupyter notebooks: https://jupyter.org
         """
         try:
-            # noinspection PyProtectedMember
-            return self.graphviz()._repr_image_svg_xml()
+            try:
+                # noinspection PyProtectedMember
+                return str(self.graphviz()._repr_svg_())
+            except AttributeError:
+                # noinspection PyProtectedMember
+    	        return self.graphviz()._repr_image_svg_xml()
 
         except (SubprocessError, ExecutableNotFound, FileNotFoundError):
             return self.svg()

--- a/binarytree/__init__.py
+++ b/binarytree/__init__.py
@@ -509,7 +509,7 @@ class Node:
         """
         try:
             # noinspection PyProtectedMember
-            return str(self.graphviz()._repr_svg_())
+            return self.graphviz()._repr_image_svg_xml()
 
         except (SubprocessError, ExecutableNotFound, FileNotFoundError):
             return self.svg()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/54838975/165023997-3b9fc29a-1abf-4fec-9ec4-4bf2d2a9bd5f.png)


replaces Diagraph's _repr_svg() method (deprecated) into _repr_image_svg_xml()

- fixes #40